### PR TITLE
fix: update session with samesite none

### DIFF
--- a/server/api/express.js
+++ b/server/api/express.js
@@ -25,6 +25,7 @@ function setupRouting(app) {
       secret: "secret",
       resave: false,
       saveUninitialized: false,
+      sameSite: "none",
     })
   );
 


### PR DESCRIPTION
If you click this checkbox
<img width="171" alt="image" src="https://github.com/marcusryden92/beyond-todo/assets/43888637/aab75857-40cb-4a97-b7d1-b9569fd36460">



You will see that the login Set-Cookie header was blocked

<img width="683" alt="image" src="https://github.com/marcusryden92/beyond-todo/assets/43888637/add1891a-318a-42b0-8826-706bd6bf3609">


By updating the session with

```js
  app.use(
    session({
      secret: "secret",
      resave: false,
      sameSite: "none", // This line
      saveUninitialized: false,
    })
  );

```

We allow Set-Cookie headers from other domains (your server)